### PR TITLE
Add script tags to .js file

### DIFF
--- a/CustomOperatorFlags.js
+++ b/CustomOperatorFlags.js
@@ -1,5 +1,6 @@
 /** global: VRS */
-    if(VRS && VRS.globalDispatch && VRS.serverConfig) {
+    <script type="text/javascript">
+	if(VRS && VRS.globalDispatch && VRS.serverConfig) {
         VRS.globalDispatch.hook(VRS.globalEvent.bootstrapCreated, function(bootStrap) {
             if(VRS.renderPropertyHandlers) {
                 VRS.renderPropertyHandlers[VRS.RenderProperty.OperatorFlag] = new VRS.RenderPropertyHandler({
@@ -89,3 +90,4 @@
         }
         return result;
     }
+</script>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Custom operator flags for [Virtual Radar Server](https://www.virtualradarserver.
 ## Instructions
 - Clone or download the repo into a directory on the machine where VRS is running. Ensure you do not place the files under the Virtual Radar Server directory, since they could be overwritten on upgrades.
 
-- Copy the desired files contained in the 'OperatorFlags' folder you've just downloaded, and paste them into the VRS 'Operator Flags' folder configured under the Tools/Options/Data Sources tab.
+- Copy the desired files contained in the 'OperatorFlags' folder you've just downloaded, and paste them into the VRS 'Operator Flags' folder configured under the Tools/Options/Data Sources tab. 
 
 - With the Custom Content Plugin enabled on VRS, go to "Tools>Plugins..." and press the "Options" button. Then fill in the field "Inject file:" with absolute path to your local file "CustomOperatorFlags.js" in the *release* folder. For example `C:\Downloads\VRS-Operator-Flags\release\CustomOperatorFlags.js` then, set set the values for **At:** to *END* of *HEAD*. Set the *Address* field  to asterisk (*), and check "Enabled" to activate the plugin. Press the "OK" button.
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ Custom operator flags for [Virtual Radar Server](https://www.virtualradarserver.
 ## Instructions
 - Clone or download the repo into a directory on the machine where VRS is running. Ensure you do not place the files under the Virtual Radar Server directory, since they could be overwritten on upgrades.
 
-- Copy the desired files contained in the 'OperatorFlags' folder you've just downloaded, and paste them in your VRS 'Operator Flags' folder configured under the Tools/Options/Data Sources tab.
+- Copy the desired files contained in the 'OperatorFlags' folder you've just downloaded, and paste them into the VRS 'Operator Flags' folder configured under the Tools/Options/Data Sources tab.
 
-- With the Custom Content Plugin enabled on VRS, go to "Tools>Plugins..." and press the "Options" button. Then fill in the field "Inject file:" with absolute path to you local file "CustomOperatorFlags.js", set it to "END of HEAD", with and asterisk (*) characther on the "Address:" field, and check "Enabled" to activate the plugin. Press the "OK" button, then the "Close" button.
+- With the Custom Content Plugin enabled on VRS, go to "Tools>Plugins..." and press the "Options" button. Then fill in the field "Inject file:" with absolute path to you local file "CustomOperatorFlags.js" for example `C:\Downloads\VRS-Operator-Flags\CustomOperatorFlags.js` then, set set the values for **At:** to *END* of *HEAD*. Set the *Address* field  to asterisk (*), and check "Enabled" to activate the plugin. Press the "OK" button.
 
-- Clear your browser cache.
+When you press **OK** the plugin will note that the site root is blank. That is OK unless you need to set it for some other reason. 
+
+Press **Close** to close the plugins window.
+
+- Clear your browser cache. (Shift-reload on most browsers.)
 
 - Enjoy!
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Custom operator flags for [Virtual Radar Server](https://www.virtualradarserver.
 
 - Copy the desired files contained in the 'OperatorFlags' folder you've just downloaded, and paste them into the VRS 'Operator Flags' folder configured under the Tools/Options/Data Sources tab.
 
-- With the Custom Content Plugin enabled on VRS, go to "Tools>Plugins..." and press the "Options" button. Then fill in the field "Inject file:" with absolute path to you local file "CustomOperatorFlags.js" for example `C:\Downloads\VRS-Operator-Flags\CustomOperatorFlags.js` then, set set the values for **At:** to *END* of *HEAD*. Set the *Address* field  to asterisk (*), and check "Enabled" to activate the plugin. Press the "OK" button.
+- With the Custom Content Plugin enabled on VRS, go to "Tools>Plugins..." and press the "Options" button. Then fill in the field "Inject file:" with absolute path to your local file "CustomOperatorFlags.js" in the *release* folder. For example `C:\Downloads\VRS-Operator-Flags\release\CustomOperatorFlags.js` then, set set the values for **At:** to *END* of *HEAD*. Set the *Address* field  to asterisk (*), and check "Enabled" to activate the plugin. Press the "OK" button.
 
 When you press **OK** the plugin will note that the site root is blank. That is OK unless you need to set it for some other reason. 
 

--- a/release/CustomOperatorFlags.js
+++ b/release/CustomOperatorFlags.js
@@ -1,0 +1,93 @@
+/** global: VRS */
+    <script type="text/javascript">
+	if(VRS && VRS.globalDispatch && VRS.serverConfig) {
+        VRS.globalDispatch.hook(VRS.globalEvent.bootstrapCreated, function(bootStrap) {
+            if(VRS.renderPropertyHandlers) {
+                VRS.renderPropertyHandlers[VRS.RenderProperty.OperatorFlag] = new VRS.RenderPropertyHandler({
+                    property:               VRS.RenderProperty.OperatorFlag,
+                    surfaces:               VRS.RenderSurface.List + VRS.RenderSurface.DetailHead + VRS.RenderSurface.InfoWindow,
+                    headingKey:             'ListOperatorFlag',
+                    labelKey:               'OperatorFlag',
+                    sortableField:          VRS.AircraftListSortableField.OperatorIcao,
+                    headingAlignment:       VRS.Alignment.Centre,
+                    suppressLabelCallback:  function() { return true; },
+                    fixedWidth:             function() { return VRS.globalOptions.aircraftOperatorFlagSize.width.toString() + 'px'; },
+                    hasChangedCallback:     function(aircraft) { return aircraft.operatorIcao.chg || aircraft.icao.chg || aircraft.registration.chg || aircraft.manufacturer.chg; },
+                    renderCallback:         function(aircraft) { return customFormatOperatorIcaoImageHtmlAircraft(aircraft); },
+                    tooltipChangedCallback: function(aircraft) { return aircraft.operatorIcao.chg || aircraft.operator.chg; },
+                    tooltipCallback:        function(aircraft) { return aircraft.formatOperatorIcaoAndName(); }
+                });
+
+                VRS.renderPropertyHandlers[VRS.RenderProperty.SilhouetteAndOpFlag] = new VRS.RenderPropertyHandler({
+                    property:               VRS.RenderProperty.SilhouetteAndOpFlag,
+                    surfaces:               VRS.RenderSurface.List,
+                    headingKey:             'ListModelSilhouetteAndOpFlag',
+                    labelKey:               'SilhouetteAndOpFlag',
+                    headingAlignment:       VRS.Alignment.Centre,
+                    sortableField:          VRS.AircraftListSortableField.OperatorIcao,
+                    fixedWidth:             function() { return Math.max(VRS.globalOptions.aircraftSilhouetteSize.width, VRS.globalOptions.aircraftOperatorFlagSize.width).toString() + 'px'; },
+                    // Changed the following line to include manufacturer
+                    hasChangedCallback:     function(aircraft) { return aircraft.modelIcao.chg || aircraft.operatorIcao.chg || aircraft.registration.chg || aircraft.manufacturer.chg; },
+                    // And this line to include a call to the custom HTML
+                    renderCallback:         function(aircraft) { return aircraft.formatModelIcaoImageHtml() + customFormatOperatorIcaoImageHtmlAircraft(aircraft); },
+                    tooltipChangedCallback: function(aircraft) { return aircraft.model.chg || aircraft.modelIcao.chg || aircraft.countEngines.chg || aircraft.engineType.chg || aircraft.species.chg || aircraft.wakeTurbulenceCat.chg || aircraft.operatorIcao.chg || aircraft.operator.chg; },
+                    tooltipCallback:        function(aircraft) {
+                        var silhouetteTooltip = aircraft.formatModelIcaoNameAndDetail();
+                        var opFlagTooltip = aircraft.formatOperatorIcaoAndName();
+                        return silhouetteTooltip && opFlagTooltip ? silhouetteTooltip + '. ' + opFlagTooltip : silhouetteTooltip ? silhouetteTooltip : opFlagTooltip;
+                    }
+                });
+            }
+            
+            if(VRS.reportPropertyHandlers) {
+                VRS.reportPropertyHandlers[VRS.ReportAircraftProperty.OperatorFlag] = new VRS.ReportPropertyHandler({
+                    property:           VRS.ReportAircraftProperty.OperatorFlag,
+                    surfaces:           VRS.ReportSurface.List + VRS.ReportSurface.DetailHead,
+                    headingKey:         'ListOperatorFlag',
+                    labelKey:           'OperatorFlag',
+                    headingAlignment:   VRS.Alignment.Centre,
+                    fixedWidth:         function() { return VRS.globalOptions.aircraftOperatorFlagSize.width.toString() + 'px'; },
+                    hasValue:           function(/** VRS_JSON_REPORT_AIRCRAFT */ json) { return !!json.opFlag || !!json.icao || !!json.reg || !!json.manufacturer; },
+                    renderCallback:     function(/** VRS_JSON_REPORT_AIRCRAFT */ json) { return customFormatOperatorIcaoImageHtml(json.manufacturer, json.opFlag, json.reg, json.icao); },
+                    tooltipCallback:    function(/** VRS_JSON_REPORT_AIRCRAFT */ json) { return VRS.format.operatorIcaoAndName(json.owner, json.opFlag); }
+                });
+            }
+        });
+    }
+    
+    function customFormatOperatorIcaoImageHtmlAircraft(aircraft)
+    {
+        return customFormatOperatorIcaoImageHtml(aircraft.manufacturer.val, aircraft.operatorIcao.val, aircraft.registration.val, aircraft.icao.val);
+    }
+    
+    function customFormatOperatorIcaoImageHtml(manufacturer, operatorIcao, registration, icao)
+    {
+        var codeToUse = '';
+        codeToUse = customPipeSeparatedCode(codeToUse, registration);        
+        codeToUse = customPipeSeparatedCode(codeToUse, operatorIcao);
+        codeToUse = customPipeSeparatedCode(codeToUse, icao);
+	codeToUse = customPipeSeparatedCode(codeToUse, manufacturer);
+
+        var size = VRS.globalOptions.aircraftOperatorFlagSize;
+        var result = '<img src="images/File-' + encodeURIComponent(codeToUse);
+        if(VRS.browserHelper.isHighDpi()) result += '/HiDpi';
+        result += '/OpFlag.png"' +
+            ' width="' + size.width.toString() + 'px"' +
+            ' height="' + size.height.toString() + 'px"' +
+            ' />';
+
+        return result;
+    }
+
+////////
+    
+    function customPipeSeparatedCode(text, code)
+    {
+        var result = text;        
+        if(code && code.length) {
+            if(result.length) result += '|';
+            result += code;
+        }
+        return result;
+    }
+</script>

--- a/source/CustomOperatorFlags.js
+++ b/source/CustomOperatorFlags.js
@@ -1,0 +1,91 @@
+/** global: VRS */
+	if(VRS && VRS.globalDispatch && VRS.serverConfig) {
+        VRS.globalDispatch.hook(VRS.globalEvent.bootstrapCreated, function(bootStrap) {
+            if(VRS.renderPropertyHandlers) {
+                VRS.renderPropertyHandlers[VRS.RenderProperty.OperatorFlag] = new VRS.RenderPropertyHandler({
+                    property:               VRS.RenderProperty.OperatorFlag,
+                    surfaces:               VRS.RenderSurface.List + VRS.RenderSurface.DetailHead + VRS.RenderSurface.InfoWindow,
+                    headingKey:             'ListOperatorFlag',
+                    labelKey:               'OperatorFlag',
+                    sortableField:          VRS.AircraftListSortableField.OperatorIcao,
+                    headingAlignment:       VRS.Alignment.Centre,
+                    suppressLabelCallback:  function() { return true; },
+                    fixedWidth:             function() { return VRS.globalOptions.aircraftOperatorFlagSize.width.toString() + 'px'; },
+                    hasChangedCallback:     function(aircraft) { return aircraft.operatorIcao.chg || aircraft.icao.chg || aircraft.registration.chg || aircraft.manufacturer.chg; },
+                    renderCallback:         function(aircraft) { return customFormatOperatorIcaoImageHtmlAircraft(aircraft); },
+                    tooltipChangedCallback: function(aircraft) { return aircraft.operatorIcao.chg || aircraft.operator.chg; },
+                    tooltipCallback:        function(aircraft) { return aircraft.formatOperatorIcaoAndName(); }
+                });
+
+                VRS.renderPropertyHandlers[VRS.RenderProperty.SilhouetteAndOpFlag] = new VRS.RenderPropertyHandler({
+                    property:               VRS.RenderProperty.SilhouetteAndOpFlag,
+                    surfaces:               VRS.RenderSurface.List,
+                    headingKey:             'ListModelSilhouetteAndOpFlag',
+                    labelKey:               'SilhouetteAndOpFlag',
+                    headingAlignment:       VRS.Alignment.Centre,
+                    sortableField:          VRS.AircraftListSortableField.OperatorIcao,
+                    fixedWidth:             function() { return Math.max(VRS.globalOptions.aircraftSilhouetteSize.width, VRS.globalOptions.aircraftOperatorFlagSize.width).toString() + 'px'; },
+                    // Changed the following line to include manufacturer
+                    hasChangedCallback:     function(aircraft) { return aircraft.modelIcao.chg || aircraft.operatorIcao.chg || aircraft.registration.chg || aircraft.manufacturer.chg; },
+                    // And this line to include a call to the custom HTML
+                    renderCallback:         function(aircraft) { return aircraft.formatModelIcaoImageHtml() + customFormatOperatorIcaoImageHtmlAircraft(aircraft); },
+                    tooltipChangedCallback: function(aircraft) { return aircraft.model.chg || aircraft.modelIcao.chg || aircraft.countEngines.chg || aircraft.engineType.chg || aircraft.species.chg || aircraft.wakeTurbulenceCat.chg || aircraft.operatorIcao.chg || aircraft.operator.chg; },
+                    tooltipCallback:        function(aircraft) {
+                        var silhouetteTooltip = aircraft.formatModelIcaoNameAndDetail();
+                        var opFlagTooltip = aircraft.formatOperatorIcaoAndName();
+                        return silhouetteTooltip && opFlagTooltip ? silhouetteTooltip + '. ' + opFlagTooltip : silhouetteTooltip ? silhouetteTooltip : opFlagTooltip;
+                    }
+                });
+            }
+            
+            if(VRS.reportPropertyHandlers) {
+                VRS.reportPropertyHandlers[VRS.ReportAircraftProperty.OperatorFlag] = new VRS.ReportPropertyHandler({
+                    property:           VRS.ReportAircraftProperty.OperatorFlag,
+                    surfaces:           VRS.ReportSurface.List + VRS.ReportSurface.DetailHead,
+                    headingKey:         'ListOperatorFlag',
+                    labelKey:           'OperatorFlag',
+                    headingAlignment:   VRS.Alignment.Centre,
+                    fixedWidth:         function() { return VRS.globalOptions.aircraftOperatorFlagSize.width.toString() + 'px'; },
+                    hasValue:           function(/** VRS_JSON_REPORT_AIRCRAFT */ json) { return !!json.opFlag || !!json.icao || !!json.reg || !!json.manufacturer; },
+                    renderCallback:     function(/** VRS_JSON_REPORT_AIRCRAFT */ json) { return customFormatOperatorIcaoImageHtml(json.manufacturer, json.opFlag, json.reg, json.icao); },
+                    tooltipCallback:    function(/** VRS_JSON_REPORT_AIRCRAFT */ json) { return VRS.format.operatorIcaoAndName(json.owner, json.opFlag); }
+                });
+            }
+        });
+    }
+    
+    function customFormatOperatorIcaoImageHtmlAircraft(aircraft)
+    {
+        return customFormatOperatorIcaoImageHtml(aircraft.manufacturer.val, aircraft.operatorIcao.val, aircraft.registration.val, aircraft.icao.val);
+    }
+    
+    function customFormatOperatorIcaoImageHtml(manufacturer, operatorIcao, registration, icao)
+    {
+        var codeToUse = '';
+        codeToUse = customPipeSeparatedCode(codeToUse, registration);        
+        codeToUse = customPipeSeparatedCode(codeToUse, operatorIcao);
+        codeToUse = customPipeSeparatedCode(codeToUse, icao);
+	codeToUse = customPipeSeparatedCode(codeToUse, manufacturer);
+
+        var size = VRS.globalOptions.aircraftOperatorFlagSize;
+        var result = '<img src="images/File-' + encodeURIComponent(codeToUse);
+        if(VRS.browserHelper.isHighDpi()) result += '/HiDpi';
+        result += '/OpFlag.png"' +
+            ' width="' + size.width.toString() + 'px"' +
+            ' height="' + size.height.toString() + 'px"' +
+            ' />';
+
+        return result;
+    }
+
+////////
+    
+    function customPipeSeparatedCode(text, code)
+    {
+        var result = text;        
+        if(code && code.length) {
+            if(result.length) result += '|';
+            result += code;
+        }
+        return result;
+    }


### PR DESCRIPTION
Custom Content Creator injects the BARE CONTENTS of the .js file, not a link to it. As a result, the javascript is not wrapped in script tags and does not execute. So I put script tags in the .js file.   